### PR TITLE
Update i18n script

### DIFF
--- a/i18n.sh
+++ b/i18n.sh
@@ -2,7 +2,7 @@
 #
 # This script helps to add and update gettext translations to onegov modules.
 #
-MODULE="${1}"
+MODULE="${1/-/_}"
 LANGUAGE="${2}"
 
 set -eu


### PR DESCRIPTION
Should allow to compile packages with underscores (such as `onegov.election_day`) package again (with the new pip setup the files are in `src/onegov.election-day/onegov/election_day/...`).